### PR TITLE
Modularize handlers, add /health endpoint, extend API tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.1.0] - 2025-04-27
+
+### Added
+- Add `GET /health` endpoint for server and Redis liveness checks
+- Support optional `mode=light` (default) or `mode=full` (Redis ping) via query parameter
+- Extend `api-test.py` to validate health checks (no params, mode=full, mode=light)
+
+### Changed
+- Modularize handlers: split movies, health, and shared_types into separate modules
+- Improve server startup logging: include version and bind address at launch
+
+## [1.0.1] - 2025-04-27
+
+### Changed
+- Update README.md to reflect `/movies` API namespace restructure
+- Document all CRUD operations (POST, GET, PUT, DELETE) under `/movies`
+- Update usage instructions to refer to `api-test.py` instead of `api-demo.sh`
+
 ## [1.0.0] - 2025-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "axum-quickstart"
-version = "2.0.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then visit: [http://localhost:8080](http://localhost:8080)
 
 ## Endpoints
 
+---
 ### `POST /movies/add`
 
 - Adds a new movie to the database.
@@ -45,6 +46,7 @@ curl -X POST http://localhost:8080/movies/add   -H "Content-Type: application/js
       }'
 ```
 
+---
 ### `GET /movies/get/{id}`
 
 - Fetches the movie with the given `id`.
@@ -55,6 +57,7 @@ curl -X POST http://localhost:8080/movies/add   -H "Content-Type: application/js
 curl http://localhost:8080/movies/get/t1994Qw22
 ```
 
+---
 ### `PUT /movies/update/{id}`
 
 - Updates an existing movie by `id`.
@@ -70,6 +73,7 @@ curl -X PUT http://localhost:8080/movies/update/t1994Qw22   -H "Content-Type: ap
       }'
 ```
 
+---
 ### `DELETE /movies/delete/{id}`
 
 - Deletes a movie from the database by `id`.
@@ -79,6 +83,24 @@ curl -X PUT http://localhost:8080/movies/update/t1994Qw22   -H "Content-Type: ap
 curl -X DELETE http://localhost:8080/movies/delete/t1994Qw22
 ```
 
+---
+### `GET /health`
+
+- Checks if the server (and optionally the Redis backend) are healthy.
+- Optional query parameter `mode`:
+  - `mode=light` (default) — basic server liveness check (server responding)
+  - `mode=full` — ping Redis backend to ensure database connectivity
+
+**Examples:**
+```bash
+# Basic liveness check
+curl http://localhost:8080/health
+
+# Full health check (including Redis)
+curl http://localhost:8080/health?mode=full
+```
+
+---
 ## Testing the API
 
 See [`api-test.py`](./api-test.py) for a detailed usage example.

--- a/api-test.py
+++ b/api-test.py
@@ -5,16 +5,19 @@ api-test.py - Integration tests for Movie API
 
 This script will:
 
-| Step                   | HTTP Verb | Endpoint                     |
-|------------------------|-----------|------------------------------|
-| Add movie              | POST      | /movies/add                  |
-| Fetch movie            | GET       | /movies/get/{id}             |
-| Update movie           | PUT       | /movies/update/{id}          |
-| Fetch updated movie    | GET       | /movies/get/{id}             |
-| Delete movie           | DELETE    | /movies/delete/{id}          |
-| Fetch deleted movie    | GET       | /movies/get/{id} (expect 404)|
-| Fetch nonexistent movie| GET       | /movies/get/nonexistent123 (expect 404) |
-
+| Step                      | HTTP Verb | Endpoint                     |
+|---------------------------|-----------|------------------------------|
+| Add movie                 | POST      | /movies/add                  |
+| Fetch movie               | GET       | /movies/get/{id}             |
+| Update movie              | PUT       | /movies/update/{id}          |
+| Fetch updated movie       | GET       | /movies/get/{id}             |
+| Delete movie              | DELETE    | /movies/delete/{id}          |
+| Fetch deleted movie       | GET       | /movies/get/{id} (expect 404)|
+| Fetch nonexistent movie   | GET       | /movies/get/nonexistent123 (expect 404) |
+| Health check (no params)  | GET       | /health                      |
+| Health check (mode=full)  | GET       | /health?mode=full            |
+| Health check (mode=light) | GET       | /health?mode=light           |
+ 
 Notes:
 - Verifies successful adds, updates, deletions.
 - Confirms 404 behavior for missing or deleted entries.
@@ -40,6 +43,28 @@ def assert_status(response, expected_status, description=""):
         sys.exit(1)
     else:
         print(f"✅ PASS: {description}")
+
+verbose = False
+
+def test_health_checks():
+    # 1. Light check (no params)
+    print("\n -- Checking health endpoint (light, no params)...")
+    response = requests.get(f"{BASE_URL}/health")
+    assert_status(response, 200, "Health check (no params)")
+    if verbose: pretty_print(response)
+
+    # 2. Full check (ping Redis)
+    print("\n -- Checking health endpoint (mode=full)...")
+    response = requests.get(f"{BASE_URL}/health?mode=full")
+    assert_status(response, 200, "Health check (mode=full)")
+    if verbose: pretty_print(response)
+
+    # 3. Explicit light check
+    print("\n -- Checking health endpoint (mode=light)...")
+    response = requests.get(f"{BASE_URL}/health?mode=light")
+    assert_status(response, 200, "Health check (mode=light)")
+    if verbose: pretty_print(response)
+
 
 def main():
     movie_id = f"t{uuid.uuid4().hex[:8]}"  # generate a random ID
@@ -93,7 +118,7 @@ def main():
     response = requests.get(f"{BASE_URL}/movies/get/" + fake_id)
     assert_status(response, 404, "Fetch non-existent movie (GET /movies/get/{id})")
 
-    print("\n🎉 All tests passed successfully!")
-
 if __name__ == "__main__":
+    test_health_checks()
     main()
+    print("\n🎉 All tests passed successfully!")

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -1,0 +1,71 @@
+use axum::{Json, extract::{Query, State}, http::StatusCode};
+use serde::Deserialize;
+use crate::AppState;
+use redis::AsyncCommands;
+
+#[derive(serde::Serialize)]
+pub struct HealthResponse {
+    status: &'static str,
+}
+
+#[derive(Deserialize)]
+pub struct HealthQuery {
+    mode: Option<String>,
+}
+
+/// Responds with the health status of the server.
+///
+/// - By default (no query parameters), performs a light check to confirm the web server
+///   is running.
+///
+/// - If `mode=full` is passed as a query parameter, also pings the Redis backend to
+///   verify database connectivity.
+///
+/// # Query Parameters
+/// - `mode`: Optional. Accepts `"light"` (default) or `"full"`.
+///
+/// # Responses
+/// - `200 OK` with `{ "status": "ok" }` if server (and Redis, in full mode) are healthy.
+/// - `500 INTERNAL SERVER ERROR` with `{ "status": "error" }` if Redis connection or ping fails in full mode.
+///
+/// # Examples
+/// - `GET /health` → 200 OK
+/// - `GET /health?mode=full` → 200 OK or 500 INTERNAL SERVER ERROR
+pub async fn health_check(
+    State(state): State<AppState>,
+    Query(params): Query<HealthQuery>,
+) -> (StatusCode, Json<HealthResponse>) {
+    match params.mode.as_deref() {
+        Some("full") => {
+            // Full health check: Ping Redis
+            let mut conn = match state.get_conn().await {
+                Ok(conn) => conn,
+                Err(_) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(HealthResponse { status: "error" })
+                    )
+                }
+            };
+
+            let ping_result: redis::RedisResult<String> = conn.ping().await;
+            match ping_result {
+                Ok(_) => (
+                    StatusCode::OK,
+                    Json(HealthResponse { status: "ok" })
+                ),
+                Err(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(HealthResponse { status: "error" })
+                ),
+            }
+        }
+        _ => {
+            // Light health check
+            (
+                StatusCode::OK,
+                Json(HealthResponse { status: "ok" })
+            )
+        }
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,3 @@
+pub mod movies;
+pub mod health;
+pub mod shared_types;

--- a/src/handlers/movies.rs
+++ b/src/handlers/movies.rs
@@ -1,0 +1,162 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode
+};
+use crate::handlers::shared_types::ApiResponse;
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use crate::AppState;
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Movie {
+    id: String,
+    title: String,
+    year: u16,
+    stars: f32,
+}
+
+/// Handler for fetching a movie entry by ID (GET /get/{id}).
+///
+/// Looks up a movie by its unique ID in the database.
+///
+/// - If the movie exists, responds with `200 OK` and the full `Movie` object as JSON.
+/// - If the movie does not exist, responds with `404 Not Found` and an empty body.
+///
+/// This endpoint enforces correct HTTP semantics for missing resources.
+#[tracing::instrument(skip(state, id))]
+pub async fn get_movie(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<(StatusCode, ApiResponse<Movie>), StatusCode> {
+    // ---
+    let mut conn = state.get_conn().await?;
+
+    let fields: Vec<(String, String)> = conn
+        .hgetall(&id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if fields.is_empty() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let map: std::collections::HashMap<String, String> = fields.into_iter().collect();
+    let movie = Movie {
+        id: map.get("id").cloned().unwrap_or_default(),
+        title: map.get("title").cloned().unwrap_or_default(),
+        year: map.get("year").and_then(|y| y.parse().ok()).unwrap_or(0),
+        stars: map.get("stars").and_then(|s| s.parse().ok()).unwrap_or(0.0),
+    };
+
+    Ok((StatusCode::OK, ApiResponse { data: movie }))
+}
+
+async fn save_movie(
+    conn: &mut redis::aio::MultiplexedConnection,
+    movie_id: &str,
+    movie: &Movie,
+    allow_overwrite: bool,
+) -> Result<StatusCode, StatusCode> {
+    // ---
+    if !allow_overwrite {
+        let exists: bool = conn
+            .exists(movie_id)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        if exists {
+            return Err(StatusCode::CONFLICT);
+        }
+    }
+
+    let _: () = conn
+        .hset_multiple(
+            movie_id,
+            &[
+                ("id", &movie.id),
+                ("title", &movie.title),
+                ("year", &movie.year.to_string()),
+                ("stars", &movie.stars.to_string()),
+            ],
+        )
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if allow_overwrite {
+        Ok(StatusCode::OK)
+    } else {
+        Ok(StatusCode::CREATED)
+    }
+}
+
+/// Handler for creating a new movie entry (POST /add).
+///
+/// Expects a complete `Movie` object in the request body.
+///
+/// - If the movie ID already exists in the database, responds with `409 Conflict`.
+/// - On success, responds with `201 Created`.
+///
+/// This endpoint enforces uniqueness of movie IDs.
+#[tracing::instrument(skip(state, movie))]
+pub async fn add_movie(
+    State(state): State<AppState>,
+    Json(movie): Json<Movie>,
+) -> Result<StatusCode, StatusCode> {
+    // ---
+    let mut conn = state.get_conn().await?;
+
+    save_movie(&mut conn, &movie.id, &movie, false).await
+}
+
+/// Handler for updating an existing movie entry (PUT /update/{id}).
+///
+/// Expects a complete `Movie` object in the request body.
+///
+/// - Always overwrites any existing movie with the provided ID.
+/// - Responds with `200 OK` regardless of whether the movie previously existed.
+///
+/// This endpoint allows overwriting or creating movies freely.
+#[tracing::instrument(skip(state, updated_movie))]
+pub async fn update_movie(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(updated_movie): Json<Movie>,
+) -> Result<StatusCode, StatusCode> {
+    // ---
+    let mut conn = state.get_conn().await?;
+
+    save_movie(&mut conn, &id, &updated_movie, true).await
+}
+
+/// Delete a movie from the Redis database by its ID.
+///
+/// Returns:
+/// - `204 No Content` if the movie was successfully deleted.
+/// - `404 Not Found` if no movie exists with the given ID.
+/// - `500 Internal Server Error` if there is a Redis connection or command failure.
+///
+/// # Arguments
+/// - `State(state)`: The application state, providing a Redis connection.
+/// - `Path(id)`: The ID of the movie to delete.
+///
+/// # Errors
+/// Returns a `StatusCode` error on failure, following the rules above.
+pub async fn delete_movie(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    // ---
+    let mut conn = state.get_conn().await?;
+
+    let deleted: u64 = conn
+        .del(&id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if deleted == 0 {
+        Err(StatusCode::NOT_FOUND)
+    } else {
+        Ok(StatusCode::NO_CONTENT)
+    }
+}
+

--- a/src/handlers/shared_types.rs
+++ b/src/handlers/shared_types.rs
@@ -1,0 +1,21 @@
+use serde::Serialize;
+use axum::response::{IntoResponse, Response};
+
+/// Wrapper type for successful API responses.
+///
+/// Encapsulates the data payload and prepares it for JSON serialization.
+#[derive(Serialize)]
+pub struct ApiResponse<T> {
+    pub data: T,
+}
+
+impl<T> IntoResponse for ApiResponse<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        axum::Json(self).into_response()
+    }
+}
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,186 +1,13 @@
 use anyhow::Result;
-use axum::{
-    extract::{Path, State},
-    http::StatusCode,
-    routing::{get, delete, post, put},
-    Json, Router,
-};
-use redis::{AsyncCommands, Client};
-use serde::{Deserialize, Serialize};
+use axum::{http::StatusCode, Router, routing::{get, delete, post, put},};
+use redis::Client;
 use std::env;
 use tracing::{error, info};
-use tracing_subscriber;
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-struct Movie {
-    id: String,
-    title: String,
-    year: u16,
-    stars: f32,
-}
+mod handlers;
 
-use axum::response::{IntoResponse, Response};
-
-/// Wrapper type for successful API responses.
-///
-/// Encapsulates the data payload and prepares it for JSON serialization.
-#[derive(Serialize)]
-struct ApiResponse<T> {
-    data: T,
-}
-
-impl<T> IntoResponse for ApiResponse<T>
-where
-    T: Serialize,
-{
-    fn into_response(self) -> Response {
-        axum::Json(self).into_response()
-    }
-}
-
-/// Handler for fetching a movie entry by ID (GET /get/{id}).
-///
-/// Looks up a movie by its unique ID in the database.
-///
-/// - If the movie exists, responds with `200 OK` and the full `Movie` object as JSON.
-/// - If the movie does not exist, responds with `404 Not Found` and an empty body.
-///
-/// This endpoint enforces correct HTTP semantics for missing resources.
-#[tracing::instrument(skip(state, id))]
-async fn get_movie(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> Result<(StatusCode, ApiResponse<Movie>), StatusCode> {
-    // ---
-    let mut conn = state.get_conn().await?;
-
-    let fields: Vec<(String, String)> = conn
-        .hgetall(&id)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    if fields.is_empty() {
-        return Err(StatusCode::NOT_FOUND);
-    }
-
-    let map: std::collections::HashMap<String, String> = fields.into_iter().collect();
-    let movie = Movie {
-        id: map.get("id").cloned().unwrap_or_default(),
-        title: map.get("title").cloned().unwrap_or_default(),
-        year: map.get("year").and_then(|y| y.parse().ok()).unwrap_or(0),
-        stars: map.get("stars").and_then(|s| s.parse().ok()).unwrap_or(0.0),
-    };
-
-    Ok((StatusCode::OK, ApiResponse { data: movie }))
-}
-
-async fn save_movie(
-    conn: &mut redis::aio::MultiplexedConnection,
-    movie_id: &str,
-    movie: &Movie,
-    allow_overwrite: bool,
-) -> Result<StatusCode, StatusCode> {
-    // ---
-    if !allow_overwrite {
-        let exists: bool = conn
-            .exists(movie_id)
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        if exists {
-            return Err(StatusCode::CONFLICT);
-        }
-    }
-
-    let _: () = conn
-        .hset_multiple(
-            movie_id,
-            &[
-                ("id", &movie.id),
-                ("title", &movie.title),
-                ("year", &movie.year.to_string()),
-                ("stars", &movie.stars.to_string()),
-            ],
-        )
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    if allow_overwrite {
-        Ok(StatusCode::OK)
-    } else {
-        Ok(StatusCode::CREATED)
-    }
-}
-
-/// Handler for creating a new movie entry (POST /add).
-///
-/// Expects a complete `Movie` object in the request body.
-///
-/// - If the movie ID already exists in the database, responds with `409 Conflict`.
-/// - On success, responds with `201 Created`.
-///
-/// This endpoint enforces uniqueness of movie IDs.
-#[tracing::instrument(skip(state, movie))]
-async fn add_movie(
-    State(state): State<AppState>,
-    Json(movie): Json<Movie>,
-) -> Result<StatusCode, StatusCode> {
-    // ---
-    let mut conn = state.get_conn().await?;
-
-    save_movie(&mut conn, &movie.id, &movie, false).await
-}
-
-/// Handler for updating an existing movie entry (PUT /update/{id}).
-///
-/// Expects a complete `Movie` object in the request body.
-///
-/// - Always overwrites any existing movie with the provided ID.
-/// - Responds with `200 OK` regardless of whether the movie previously existed.
-///
-/// This endpoint allows overwriting or creating movies freely.
-#[tracing::instrument(skip(state, updated_movie))]
-async fn update_movie(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-    Json(updated_movie): Json<Movie>,
-) -> Result<StatusCode, StatusCode> {
-    // ---
-    let mut conn = state.get_conn().await?;
-
-    save_movie(&mut conn, &id, &updated_movie, true).await
-}
-
-/// Delete a movie from the Redis database by its ID.
-///
-/// Returns:
-/// - `204 No Content` if the movie was successfully deleted.
-/// - `404 Not Found` if no movie exists with the given ID.
-/// - `500 Internal Server Error` if there is a Redis connection or command failure.
-///
-/// # Arguments
-/// - `State(state)`: The application state, providing a Redis connection.
-/// - `Path(id)`: The ID of the movie to delete.
-///
-/// # Errors
-/// Returns a `StatusCode` error on failure, following the rules above.
-async fn delete_movie(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> Result<StatusCode, StatusCode> {
-    // ---
-    let mut conn = state.get_conn().await?;
-
-    let deleted: u64 = conn
-        .del(&id)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    if deleted == 0 {
-        Err(StatusCode::NOT_FOUND)
-    } else {
-        Ok(StatusCode::NO_CONTENT)
-    }
-}
+use handlers::movies::*;
+use handlers::health::health_check;
 
 /// Shared application state passed to all Axum handlers.
 ///
@@ -249,6 +76,7 @@ async fn main() -> Result<()> {
     let redis_client = Client::open(redis_url)?;
 
     let app = Router::new()
+        .route("/health", get(health_check))
         .nest("/movies", Router::new()
               .route("/get/{id}", get(get_movie))
               .route("/add", post(add_movie))


### PR DESCRIPTION
This PR modularizes the project by moving handlers into separate modules (`movies.rs`, `health.rs`, `shared_types.rs`), adds a production-ready `/health` endpoint supporting optional Redis ping checks, and extends integration testing to fully cover the new /health functionality.

- Split movies, health, and shared types into separate modules
- Add GET /health endpoint with optional mode=full to ping Redis
- Update api-test.py to validate /health (no params, full, light)
- Update changelog entries for v1.0.1 and v1.1.0